### PR TITLE
Format the stack when errors occur

### DIFF
--- a/src/bin/server.js
+++ b/src/bin/server.js
@@ -29,6 +29,7 @@ app.use(webpackDevMiddleware(compiler, {
 }));
 
 const {
+  formatErrorStack,
   createCompilationPromise,
   evalBundleCode
 } = createIsomorphicWebpack(webpackConfiguration, {
@@ -62,6 +63,15 @@ app.get('/', (req, res) => {
   const userFacingApp = renderToString(evalBundleCode(requestUrl).default);
 
   res.send(renderFullPage(userFacingApp));
+});
+
+// eslint-disable-next-line no-unused-vars
+app.use((err, req, res, next) => {
+  const formattedErr = formatErrorStack(err.stack);
+
+  // eslint-disable-next-line no-console
+  console.error(formattedErr);
+  res.status(500).type('text/plain').send(formattedErr);
 });
 
 app.listen(8000);

--- a/src/bin/server.js
+++ b/src/bin/server.js
@@ -59,9 +59,9 @@ const renderFullPage = (body) => {
 app.get('/', (req, res) => {
   const requestUrl = req.protocol + '://' + req.get('host') + req.originalUrl;
 
-  const app = renderToString(evalBundleCode(requestUrl).default);
+  const userFacingApp = renderToString(evalBundleCode(requestUrl).default);
 
-  res.send(renderFullPage(app));
+  res.send(renderFullPage(userFacingApp));
 });
 
 app.listen(8000);


### PR DESCRIPTION
Before:
<img width="580" alt="screen shot 2017-03-22 at 11 31 30 pm" src="https://cloud.githubusercontent.com/assets/3682844/24230974/5500a4f6-0f58-11e7-9af0-fe39f08629ca.png">

After:
<img width="582" alt="screen shot 2017-03-22 at 11 31 50 pm" src="https://cloud.githubusercontent.com/assets/3682844/24230984/5ee8edac-0f58-11e7-861e-12dd2d20521f.png">